### PR TITLE
Add starter version of deploy-api-gateway.js file

### DIFF
--- a/scripts/module_06/deploy-api-gateway.js
+++ b/scripts/module_06/deploy-api-gateway.js
@@ -1,0 +1,19 @@
+// Imports
+const AWS = require('aws-sdk')
+
+AWS.config.update({ region: '/* TODO: Add your region */' })
+
+// Declare local variables
+const apiG = new AWS.APIGateway()
+const apiId = '/* TODO: Add api id */'
+
+createDeployment(apiId, 'prod')
+.then(data => console.log(data))
+
+function createDeployment (apiId, stageName) {
+  // TODO: Create params const
+
+  return new Promise((resolve, reject) => {
+    // TODO: Create deployment
+  })
+}


### PR DESCRIPTION
This file is referenced in module_06, but does not appear to be present in the
project.  Adding a starter version of the file based on what is shown in the
course video content.